### PR TITLE
feat(wrapper): auto-download missing models on API start

### DIFF
--- a/README-FOR-WRAPPER.md
+++ b/README-FOR-WRAPPER.md
@@ -23,6 +23,7 @@
 - ローカルでリアルタイム音声→文字起こしを試す（GUI から Start/録音/表示/保存）。
 - 既存アプリから OpenAI Whisper API 互換 REST を呼ぶ（`POST /v1/audio/transcriptions`）。
 - モデル/VAD のダウンロード・管理（GUIの Model Manager）。
+  - API 起動時、必要な Whisper/VAD/話者分離モデルがローカルに無ければ自動でダウンロードし、設定画面から確認・削除できる。
 
 ## アーキテクチャ
 - GUI 層（Tkinter）: `wrapper/cli/main.py` → `wrapper/app/gui.py`

--- a/WRAPPER-DEV-LOG.md
+++ b/WRAPPER-DEV-LOG.md
@@ -952,5 +952,18 @@
 - 変更内容:
   - `wrapper/app/gui.py`: ヘッダーに Start/Stop を配置、左端に折りたたみボタン追加（`_toggle_main_sections`）。`settings_collapsed` を設定ファイルに保存。
   - 右カラムの比率を Recorder:Logs=3:4 に変更し、トランスクリプト欄の高さを体感で約 2/3 に抑制。
-  - `README-FOR-WRAPPER.md` に設計変更を反映。
-− 未解決事項: 折りたたみ時に PanedWindow のサッシュ位置復元は未実装（必要性が出たら検討）。
+- `README-FOR-WRAPPER.md` に設計変更を反映。
+- 未解決事項: 折りたたみ時に PanedWindow のサッシュ位置復元は未実装（必要性が出たら検討）。
+
+
+## 2025-09-05 (モデル自動ダウンロード)
+
+- 決定事項: API 起動時に Whisper/VAD/話者分離モデルがローカルに無い場合、自動でダウンロードする機構を追加。SimulStreaming backend もラッパー側で事前取得する。
+- 根拠: ユーザー操作後にモデル欠如で失敗するのを防ぎ、設定画面からダウンロード済みモデルを一元管理できるようにするため。
+- 変更内容:
+  - `wrapper/app/model_manager.py`: SimulStreaming 用 `.pt` モデルの検出・取得・削除を実装し、`list_downloaded_models` 等を拡張。
+  - `wrapper/app/gui.py`: API 起動時のモデル存在チェックを全バックエンドで実施し、不足時は事前ダウンロード。SimulStreaming 起動引数を `--model_dir` に統一。
+  - `README-FOR-WRAPPER.md`: API 起動時の自動ダウンロード仕様を追記。
+- 未解決事項: 既存の `.pt` のみを保持するユーザー環境では、初回起動時に Hugging Face スナップショットが追加でダウンロードされる（重複ストレージ使用の可能性）。
+- 次アクション: ユーザーフィードバックを元に `.pt` 単体管理への最適化を検討。
+- リスク・課題: SimulStreaming 以外の新規バックエンド追加時にモデル検出ロジックの拡張が必要となる。


### PR DESCRIPTION
## Summary
- ensure wrapper downloads Whisper/VAD/diarization models when starting the API
- support SimulStreaming by managing `.pt` model files in cache
- document auto-download behaviour and update development log

## Testing
- `python -m py_compile wrapper/app/model_manager.py wrapper/app/gui.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba5e3e55ec832faf0150614265eaf4