### PR TITLE
feat: separate backend model management

### DIFF
--- a/README-FOR-WRAPPER.md
+++ b/README-FOR-WRAPPER.md
@@ -24,6 +24,7 @@
 - 既存アプリから OpenAI Whisper API 互換 REST を呼ぶ（`POST /v1/audio/transcriptions`）。
 - モデル/VAD のダウンロード・管理（GUIの Model Manager）。
   - API 起動時、必要な Whisper/VAD/話者分離モデルがローカルに無ければ自動でダウンロードし、設定画面から確認・削除できる。
+  - SimulStreaming と faster-whisper は専用のモデルファイルを使用するため、Model Manager でバックエンドごとに個別にダウンロード・削除できる。既存のダウンロード済みモデルはそのまま利用できるが、他バックエンドを使う場合は各バックエンド用モデルを追加取得する。
 
 ## アーキテクチャ
 - GUI 層（Tkinter）: `wrapper/cli/main.py` → `wrapper/app/gui.py`

--- a/WRAPPER-DEV-LOG.md
+++ b/WRAPPER-DEV-LOG.md
@@ -1,5 +1,20 @@
 # WRAPPER-DEV-LOG
 
+## 2025-10-20 (バックエンド別モデル管理)
+- 背景／スコープ：SimulStreaming と faster-whisper のモデルファイルが同一扱いで表示され、誤操作の恐れがあった。
+- 決定事項：
+  - Whisper モデルをバックエンドごとに区別し、Model Manager から個別にダウンロード・削除できるようにした。
+  - `model_manager.delete_model` に `backend` 引数を追加。
+  - CLI `model_manager_cli.py` に `--backend` オプションを追加し、各操作で指定可能とした。
+- 根拠・検討メモ：バックエンドごとに使用するモデル形式が異なり、混同すると適切に管理できないため。
+- 未解決事項：設定ファイルの `model` はバックエンド共通名称のままであり、複数バックエンドを併用する際は各バックエンド用モデルを個別に取得する必要がある。
+- 次アクション：ユーザーフィードバックを収集し、UI 改善や自動取得の拡張を検討。
+- 参照リンク：
+  - `wrapper/app/gui.py`
+  - `wrapper/app/model_manager.py`
+  - `wrapper/cli/model_manager_cli.py`
+  - `README-FOR-WRAPPER.md`
+
 ## 2025-10-19 (FFmpeg 未導入時のAPI起動防止)
 - 背景／スコープ：FFmpeg がインストールされていない環境で Start API を押すと、起動途中でエラーとなりGUIの状態が不定になるケースがあった。
 - 決定事項：

--- a/wrapper/app/model_manager.py
+++ b/wrapper/app/model_manager.py
@@ -183,14 +183,15 @@ def download_model(
     return path
 
 
-def delete_model(name: str) -> None:
+def delete_model(name: str, *, backend: Optional[str] = None) -> None:
     if name == VAD_REPO:
         _delete_vad_model()
         return
-    repo = _resolve_repo_id(name)
+    repo = _resolve_repo_id(name, backend=backend)
     shutil.rmtree(_cache_dir(repo), ignore_errors=True)
     # Remove potential .pt file for simulstreaming/openai models
-    try:
-        _pt_file(name).unlink()
-    except Exception:
-        pass
+    if backend in (None, "simulstreaming"):
+        try:
+            _pt_file(name).unlink()
+        except Exception:
+            pass

--- a/wrapper/cli/model_manager_cli.py
+++ b/wrapper/cli/model_manager_cli.py
@@ -32,15 +32,19 @@ def main() -> None:
     sub.add_parser("list")
     p_is = sub.add_parser("is_downloaded")
     p_is.add_argument("name")
+    p_is.add_argument("--backend", choices=["faster-whisper", "simulstreaming"], default=None)
 
     p_dl = sub.add_parser("download")
     p_dl.add_argument("name")
+    p_dl.add_argument("--backend", choices=["faster-whisper", "simulstreaming"], default=None)
 
     p_rm = sub.add_parser("delete")
     p_rm.add_argument("name")
+    p_rm.add_argument("--backend", choices=["faster-whisper", "simulstreaming"], default=None)
 
     p_path = sub.add_parser("get_path")
     p_path.add_argument("name")
+    p_path.add_argument("--backend", choices=["faster-whisper", "simulstreaming"], default=None)
 
     args = ap.parse_args()
 
@@ -48,10 +52,10 @@ def main() -> None:
         print(json.dumps(model_manager.list_downloaded_models()))
         return
     if args.cmd == "is_downloaded":
-        print("1" if model_manager.is_model_downloaded(args.name) else "0")
+        print("1" if model_manager.is_model_downloaded(args.name, backend=args.backend) else "0")
         return
     if args.cmd == "get_path":
-        print(str(model_manager.get_model_path(args.name)))
+        print(str(model_manager.get_model_path(args.name, backend=args.backend)))
         return
     if args.cmd == "download":
         def _cb(fr: float) -> None:
@@ -60,10 +64,10 @@ def main() -> None:
             except Exception:
                 pass
 
-        model_manager.download_model(args.name, progress_cb=_cb)
+        model_manager.download_model(args.name, backend=args.backend, progress_cb=_cb)
         return
     if args.cmd == "delete":
-        model_manager.delete_model(args.name)
+        model_manager.delete_model(args.name, backend=args.backend)
         return
 
 


### PR DESCRIPTION
## Summary
- track SimulStreaming and faster-whisper weights separately in GUI model manager
- expose backend selection in model_manager CLI and backend-aware delete_model
- document backend-specific model handling and log the change

## Testing
- `python -m py_compile wrapper/app/model_manager.py wrapper/app/gui.py wrapper/cli/model_manager_cli.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba6ec6ee88832f9e377e3a531f258c