### PR TITLE
fix: ensure backend VAD download trusts repo

### DIFF
--- a/WRAPPER-DEV-LOG.md
+++ b/WRAPPER-DEV-LOG.md
@@ -1,5 +1,27 @@
 # WRAPPER-DEV-LOG
 
+## 2025-10-23 (torch.hub trust_repo パッチ適用)
+- 背景／スコープ：backend の VAD ダウンロードで `trust_repo` 未指定により PyTorch 2.x で失敗するケースがあった。
+- 決定事項：wrapper 独自の `backend_launcher` を追加し、`torch.hub.load` をラップして `trust_repo=True` を既定化。
+- 根拠・検討メモ：`TranscriptionEngine` 内 `torch.hub.load` の仕様が固定のため、ラッパー側でモンキーパッチすることで互換性を確保。
+- 未解決事項：upstream への正式修正は未反映。
+- 次アクション：upstream へ修正提案を継続。
+- リスク／課題：信頼済みリポジトリ指定によりリモートコード実行リスクがあるため、ダウンロード元の健全性監視が必要。
+- 参照リンク：
+  - `wrapper/app/backend_launcher.py`
+  - `wrapper/app/gui.py`
+
+## 2025-10-22 (VADモデル読み込み時のtrust_repo指定漏れ)
+- 背景／スコープ：VADモデル読み込み時にtorch.hub.loadへtrust_repo引数が未指定のため、PyTorch 2.x環境で実行時に例外が発生する恐れがある。
+- 決定事項：upstreamのTranscriptionEngine内torch.hub.load呼び出しにtrust_repo=Trueを追加するパッチ案を検討。
+- 根拠・検討メモ：wrapper側のmodel_managerではtrust_repoを付与しており挙動が安定しているが、backend側では省略されている。
+- 未解決事項：upstreamで修正が受け入れられるか未定。
+- 次アクション：upstreamへパッチ提案を送付し、採用可否を確認。
+- リスク／課題：現状のままではオフライン環境や厳格なtorch.hub設定でVADが初期化できない可能性。
+- 参照リンク：
+  - `whisperlivekit/core.py`
+  - `wrapper/app/model_manager.py`
+
 ## 2025-10-21 (自動保存とモデル表示の改良)
 - 背景／スコープ：録音結果の保存方法と Whisper モデルの表示区分が分かりにくかった。
 - 決定事項：

--- a/wrapper/app/backend_launcher.py
+++ b/wrapper/app/backend_launcher.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Backend launcher that ensures torch.hub.load trusts the repository.
+
+This is a workaround for upstream TranscriptionEngine which calls
+``torch.hub.load`` without ``trust_repo=True`` when downloading the
+Silero VAD model. PyTorch 2.x defaults to trusting none which may raise
+an exception on first download. By monkeypatching ``torch.hub.load`` to
+set ``trust_repo=True`` when unspecified, the backend remains compatible
+without requiring upstream modification.
+"""
+
+import importlib
+import sys
+
+
+def _patch_torch_hub() -> None:
+    import torch.hub as hub  # type: ignore
+
+    _orig_load = hub.load
+
+    def _load_with_trust_repo(repo_or_dir, model, *args, trust_repo=None, **kwargs):
+        if trust_repo is None:
+            trust_repo = True
+        return _orig_load(repo_or_dir, model, *args, trust_repo=trust_repo, **kwargs)
+
+    hub.load = _load_with_trust_repo
+
+
+_patch_torch_hub()
+
+# Defer import until after patching
+basic_server = importlib.import_module("whisperlivekit.basic_server")
+
+
+def main() -> None:
+    basic_server.main()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/wrapper/app/gui.py
+++ b/wrapper/app/gui.py
@@ -1427,7 +1427,7 @@ class WrapperGUI:
             sys.executable,
             "-u",
             "-m",
-            "whisperlivekit.basic_server",
+            "wrapper.app.backend_launcher",
             "--host",
             b_host,
             "--port",


### PR DESCRIPTION
## Summary
- wrap backend startup to force `torch.hub.load(..., trust_repo=True)`
- document new launcher and record decision in dev log

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bace3f0138832fad994ec8bd3487e6