### PR TITLE
Align integration test backend model selection with GUI

### DIFF
--- a/README-FOR-WRAPPER.md
+++ b/README-FOR-WRAPPER.md
@@ -146,6 +146,9 @@
 - 設定テンプレート: `wrapper/config/`
 - ライセンス一覧: `wrapper/licenses.json`
 
+## テスト
+- `python wrapper/scripts/full_stack_integration_test.py`: GUI の「Start API」と同等の経路をスタブ環境で再現し、GUI から管理できるすべてのモデル種別（Whisper 各バックエンド、VAD、セグメンテーション、埋め込み）のダウンロード状態を検証してから REST 経路を確認する統合テスト。
+
 本仕様書と `WRAPPER-DEV-LOG.md` は、仕様変更・意思決定に合わせて更新します。
 ## GUI の振る舞い（録音・文字起こし）
 - 処理中インジケータ: 録音開始後からバックエンド側での最終処理が完了するまで、録音開始ボタンの右側にスピナーを表示します。


### PR DESCRIPTION
## Summary
- derive the integration test's backend launch parameters from the GUI model catalog instead of assuming the tiny model exists
- mirror the GUI's backend CLI arguments by using backend-specific model paths and validations

## Testing
- python wrapper/scripts/full_stack_integration_test.py

------
https://chatgpt.com/codex/tasks/task_e_68cab49b8ed8832f99d09061e7cd1ded