### PR TITLE
Protect OpenAPI endpoints with API key middleware

### DIFF
--- a/README-FOR-WRAPPER.md
+++ b/README-FOR-WRAPPER.md
@@ -64,6 +64,7 @@
   - multipart フォーム: `file=@sample.wav`, `model=whisper-1`
   - 音声形式: 16kHz モノラル (wav/raw) を推奨。これらは再変換せずに処理され、その他の形式は ffmpeg により変換される。
   - APIキー（任意）: `X-API-Key: <key>` または `Authorization: Bearer <key>`
+  - `WRAPPER_REQUIRE_API_KEY=1` を設定した場合、`/v1/audio/transcriptions` だけでなく `/openapi.json` `/docs` `/redoc` などのドキュメント系エンドポイントも同じヘッダーが必須となる（未設定または誤ったキーは 401 応答）。
   - レスポンス例: `{ "text": "...", "model": "whisper-1" }`
 
 ## 実行・設定手順（概要）
@@ -103,7 +104,7 @@
 
 ## セキュリティ / プライバシー
 - デフォルトはローカルバインド。外部公開する場合は TLS/認証/ファイアウォール等を考慮。
-- Wrapper API は任意で API キーを要求可能（GUI で設定）。
+- Wrapper API は任意で API キーを要求可能（GUI で設定）。API キーを有効化すると OpenAPI/Swagger/Redoc も同じヘッダーが必要になり、認証無しでは参照できない。
 
 ## パフォーマンス目標
 - 低遅延の逐次文字起こし（数百ms〜程度のバッファリング）

--- a/WRAPPER-DEV-LOG.md
+++ b/WRAPPER-DEV-LOG.md
@@ -1,5 +1,12 @@
 # WRAPPER-DEV-LOG
 
+## 2025-10-30 (OpenAPI も API キーで保護)
+- 背景／スコープ：ラッパー API に API キーを設定しても `/openapi.json` などのドキュメント用エンドポイントが無認証で参照でき、GUI から誤設定されたキーでもアクセス可能だった。
+- 決定事項：全 HTTP リクエストに共通のミドルウェアを挟み、API キー検証を一元化。FastAPI 標準の OpenAPI/Swagger/Redoc も同じ判定を通るようにした。
+- 根拠／検討メモ：`FastAPI(..., dependencies=...)` ではドキュメント系エンドポイントに認証が適用されないため、ミドルウェアでの判定が必要だった。既存の OpenAI 風エラーハンドラを流用して 401/500 応答を統一。
+- 影響／移行：`WRAPPER_REQUIRE_API_KEY=1` を利用中のユーザーは `/openapi.json` / `/docs` / `/redoc` を参照する際にもヘッダー指定が必須になる。GUI 側でキーを配布済みなら追加設定は不要。
+- 未解決事項：WebSocket (`/asr`) を API キーで保護する仕組みは未実装。必要なら backend 側での拡張を検討。
+
 ## 2025-09-18 (faster-whisper モデル検出の修正)
 - 背景／スコープ：GUI から「Start API」を押すと faster-whisper が未ダウンロード状態でも `.pt` ファイルを既存モデルと誤認し、存在しない `--model_dir` をバックエンドに渡した結果、`huggingface_hub.HFValidationError` が発生して起動に失敗していた。
 - 決定事項：


### PR DESCRIPTION
## Summary
- enforce the API key check through a FastAPI middleware so that OpenAPI/Swagger/Redoc also require authentication when enabled
- document the new behavior in README-FOR-WRAPPER and record the decision in WRAPPER-DEV-LOG

## Testing
- python wrapper/scripts/full_stack_integration_test.py

------
https://chatgpt.com/codex/tasks/task_e_68cce45ab058832f863c25c6edb9eca8