### PR TITLE
Cache warmup audio downloads

### DIFF
--- a/README-FOR-WRAPPER.md
+++ b/README-FOR-WRAPPER.md
@@ -28,6 +28,7 @@
 - Whisperモデルは SimulStreaming 用と Faster Whisper 用に区分して一覧表示し、モデル名からバックエンド名を省いた。既存のダウンロード済みモデルはそのまま利用できるが、他バックエンドを使う場合は各バックエンド用モデルを追加取得する。
 - モデル選択欄の右側で使用するバックエンドを直接選択できるようになった。SimulStreaming を選択した場合は商用利用に別途許諾が必要である旨の注意書きを表示する。
 - Faster Whisper バックエンドのモデル取得時は、ダウンロードしたスナップショットのパスを `latest` ファイルに記録し、起動時はこれを参照してモデルを特定する。`latest` や `snapshots` が見つからない場合は `.bin` ファイル探索にフォールバックし、手動配置モデルも読み込める。
+- Faster Whisper のダウンロード判定は CTranslate2 ウェイト（`model.bin` / `model.bin.*`）とトークナイザー設定（`tokenizer.json` / `tokenizer_config.json`）が揃った場合にのみ「取得済み」と見なす。欠損状態では GUI が再ダウンロードを促し、空ディレクトリを `--model_dir` として渡してしまうことによる起動失敗を防ぐ。
 
 - 未ダウンロードのモデルを指定した場合でも、キャッシュディレクトリが存在しないことによるエラーは発生せず、必要に応じて自動ダウンロード処理に委ねられる。特に Faster Whisper バックエンドでは、モデルが未取得の場合でもモデル名を `--model` として渡すことで `Invalid model size` エラーを避けてダウンロードにフォールバックする。
 
@@ -85,6 +86,9 @@
   - より細かく制御したい場合は `WRAPPER_HF_CACHE_DIR` / `WRAPPER_TORCH_CACHE_DIR` を直接指定できる。既に
     `HUGGINGFACE_HUB_CACHE` / `HF_HOME` / `TORCH_HOME` が設定されている場合はその値を尊重し、ラッパー内部の参照も同じディレクトリに揃え
     る。
+- `--warmup-file` に HTTP(S) の URL を指定した場合は、初回アクセス時に音声ファイルを `WRAPPER_WARMUP_CACHE_DIR`（既定: `<cache>/warmups`）
+  に保存し、以後は同じキャッシュを再利用する。従来の一時ディレクトリ再ダウンロードは発生しない。既存ユーザーも自動的に新しい場所へ再
+  ダウンロードされるだけで移行作業は不要。
 - 起動時に `HUGGINGFACE_HUB_CACHE`, `HF_HOME`, `TORCH_HOME`, `HF_HUB_DISABLE_SYMLINKS` が未設定なら自動的に補完し、GUI でのモデル
   ダウンロード・バックエンド起動・CLI からの操作が同じキャッシュを使う。`HF_HUB_DISABLE_SYMLINKS=1` と
   `snapshot_download(..., local_dir_use_symlinks=False)` の併用により、MSIX/Windows のシンボリックリンク制限下でも確実に物理ファイルが

--- a/wrapper/scripts/full_stack_integration_test.py
+++ b/wrapper/scripts/full_stack_integration_test.py
@@ -196,7 +196,12 @@ def _patch_model_manager(tmp_root: Path):
         safe = repo_id.replace("/", "--")
         target = cache_path / f"models--{safe}" / "snapshots" / "stub"
         target.mkdir(parents=True, exist_ok=True)
-        (target / "pytorch_model.bin").write_bytes(b"stub")
+        if "faster-whisper" in repo_id:
+            (target / "model.bin").write_bytes(b"stub")
+            (target / "tokenizer.json").write_text("{}", encoding="utf-8")
+            (target / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+        else:
+            (target / "pytorch_model.bin").write_bytes(b"stub")
         return str(target)
 
     def fake_vad_download(progress_cb: Optional[Callable[[float], None]] = None) -> Path:

--- a/wrapper/scripts/test_fastwhisper_cache.py
+++ b/wrapper/scripts/test_fastwhisper_cache.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Regression test for faster-whisper cache detection helpers.
+
+This script creates temporary Hugging Face cache layouts that mimic the
+structures produced by ``snapshot_download`` and verifies that
+``model_manager.is_model_downloaded`` recognises valid CTranslate2 snapshots
+while rejecting incomplete ones. It is intentionally lightweight so it can be
+run in CI without network access.
+"""
+
+from __future__ import annotations
+
+import http.server
+import importlib
+import io
+import os
+import shutil
+import socketserver
+import sys
+import tempfile
+import threading
+import wave
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _reload_model_manager(tmp_dir: Path):
+    """Reload ``model_manager`` with cache paths rooted at ``tmp_dir``."""
+
+    for var in (
+        "WRAPPER_CACHE_DIR",
+        "WRAPPER_HF_CACHE_DIR",
+        "WRAPPER_TORCH_CACHE_DIR",
+        "HUGGINGFACE_HUB_CACHE",
+        "HF_HOME",
+        "TORCH_HOME",
+    ):
+        os.environ.pop(var, None)
+    os.environ["WRAPPER_CACHE_DIR"] = str(tmp_dir)
+    for key in list(sys.modules):
+        if key.startswith("wrapper.app.model_manager"):
+            sys.modules.pop(key)
+    return importlib.import_module("wrapper.app.model_manager")
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        mm = _reload_model_manager(tmp_path)
+
+        repo_dir = mm.HF_CACHE_DIR / "models--Systran--faster-whisper-tiny"
+
+        _assert(
+            not mm.is_model_downloaded("tiny", backend="faster-whisper"),
+            "Fresh cache should report the model as missing.",
+        )
+
+        repo_dir.mkdir(parents=True, exist_ok=True)
+        (repo_dir / "model.bin").write_bytes(b"0")
+        _assert(
+            not mm.is_model_downloaded("tiny", backend="faster-whisper"),
+            "Tokenizer metadata must exist alongside model.bin.",
+        )
+        (repo_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
+        _assert(
+            mm.is_model_downloaded("tiny", backend="faster-whisper"),
+            "Direct model.bin + tokenizer.json should be detected as downloaded.",
+        )
+
+        shutil.rmtree(repo_dir)
+        repo_dir.mkdir(parents=True, exist_ok=True)
+        snapshot = repo_dir / "snapshots" / "rev-123"
+        snapshot.mkdir(parents=True, exist_ok=True)
+        (snapshot / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+        _assert(
+            not mm.is_model_downloaded("tiny", backend="faster-whisper"),
+            "Weights are required before detection succeeds.",
+        )
+        (snapshot / "model.bin.0").write_bytes(b"0")
+        (snapshot / "model.bin.1").write_bytes(b"0")
+        (snapshot / "model.bin.index.json").write_text("{}", encoding="utf-8")
+        _assert(
+            mm.is_model_downloaded("tiny", backend="faster-whisper"),
+            "Sharded model weights with index metadata should be detected.",
+        )
+
+        (snapshot / "model.bin.0").unlink()
+        (snapshot / "model.bin.1").unlink()
+        _assert(
+            not mm.is_model_downloaded("tiny", backend="faster-whisper"),
+            "Removing shards should mark the model as missing again.",
+        )
+
+        local_warmup = tmp_path / "local.wav"
+        local_warmup.write_bytes(b"local")
+        _assert(
+            mm.ensure_warmup_file(str(local_warmup)) == local_warmup,
+            "Local warmup paths should be returned unchanged.",
+        )
+
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(16000)
+            wf.writeframes(b"\x00\x00" * 10)
+        sample_data = buf.getvalue()
+
+        class _WarmupHandler(http.server.BaseHTTPRequestHandler):
+            hits = 0
+
+            def do_GET(self):  # type: ignore[override]
+                type(self).hits += 1
+                self.send_response(200)
+                self.send_header("Content-Type", "audio/wav")
+                self.send_header("Content-Length", str(len(sample_data)))
+                self.end_headers()
+                self.wfile.write(sample_data)
+
+            def log_message(self, *_args, **_kwargs):  # pragma: no cover - silence test output
+                return
+
+        class _WarmupServer(socketserver.TCPServer):
+            allow_reuse_address = True
+
+        _WarmupHandler.hits = 0
+        with _WarmupServer(("127.0.0.1", 0), _WarmupHandler) as httpd:
+            thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+            thread.start()
+            try:
+                port = httpd.server_address[1]
+                url = f"http://127.0.0.1:{port}/warmup.wav"
+                _assert(
+                    mm.needs_warmup_download(url),
+                    "Remote warmup should require download when cache is empty.",
+                )
+                path = mm.ensure_warmup_file(url)
+                _assert(path.exists(), "Downloaded warmup file should exist on disk.")
+                _assert(
+                    path.read_bytes() == sample_data,
+                    "Warmup download should preserve the source bytes.",
+                )
+                _assert(
+                    not mm.needs_warmup_download(url),
+                    "Cached warmup should be detected as present.",
+                )
+                path_again = mm.ensure_warmup_file(url)
+                _assert(path_again == path, "ensure_warmup_file should reuse the cached path.")
+                _assert(
+                    _WarmupHandler.hits == 1,
+                    "Warmup HTTP handler should be hit exactly once.",
+                )
+            finally:
+                httpd.shutdown()
+                thread.join(timeout=2.0)
+
+    print("faster-whisper and warmup cache tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a warmup cache directory and helpers so HTTP(S) warmup audio is materialised once and reused on future launches
- integrate warmup prefetch into the Start API workflow with appropriate status messaging and failure recovery
- document the new behaviour and extend the regression script to cover warmup caching

## Testing
- python wrapper/scripts/test_fastwhisper_cache.py
- python wrapper/scripts/full_stack_integration_test.py

------
https://chatgpt.com/codex/tasks/task_e_68cce39f9568832fa9d2e393849b712c